### PR TITLE
Fixed iOS build when the wkwebview flag is set

### DIFF
--- a/scripts/lib/iosWKWebViewEngineSupport.js
+++ b/scripts/lib/iosWKWebViewEngineSupport.js
@@ -188,7 +188,7 @@ function setMacro(xcodeProject) {
     }
 
     var isModified = false;
-    var injectedDefinition = strFormat('"%s=%d"', WKWEBVIEW_MACRO, isWkWebViewEngineUsed);
+    var injectedDefinition = strFormat('"$(inherited) %s=%d"', WKWEBVIEW_MACRO, isWkWebViewEngineUsed);
     preprocessorDefs.forEach(function(item, idx) {
       if (item.indexOf(WKWEBVIEW_MACRO) !== -1) {
         preprocessorDefs[idx] = injectedDefinition;


### PR DESCRIPTION
- `$(inherited)` needs to be included when setting the `GCC_PREPROCESSOR_DEFINITIONS` flag, otherwise it won't build with the `wkwebview` flag set. It's a weird combination of incorrect definitions and plugins being used that causes the build to fail.